### PR TITLE
Including main property for grunt injection

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -13,8 +13,9 @@
     "type": "git",
     "url": "git://github.com/yaru22/angular-json-human.git"
   },
-  "main" : [
-      "dist/angular-json-human.js"
+  "main": [
+      "dist/angular-json-human.js",
+      "dist/angular-json-human.css"
   ],
   "ignore": [
     ".editorconfig",


### PR DESCRIPTION
When running bower-install w/in grunt, I encounter the following message:

$ grunt bower-install
Running "bower-install:app" (bower-install) task
angular-json-human was not injected in your file.
Please go take a look in "app/bower_components/angular-json-human" for the file you need, then manually include it in your file.

bower.json just needs a main property so it knows how to automatically inject the script w/in the bower:js block instead of manually including that file each time.

For more info about the main property, you can check out the bower spec @:
https://docs.google.com/document/d/1APq7oA9tNao1UYWyOm8dKqlRP2blVkROYLZ2fLIjtWc/edit#
