### PR TITLE
Add DI annotation for jsonHumanHelper directive

### DIFF
--- a/src/angular-json-human.js
+++ b/src/angular-json-human.js
@@ -4,7 +4,7 @@
 
 angular.module('yaru22.jsonHuman', [
   'yaru22.jsonHuman.tmpls'
-]).factory('RecursionHelper', ['$compile', function ($compile) {
+]).factory('RecursionHelper', function ($compile) {
   var RecursionHelper = {
     compile: function (element) {
       var contents = element.contents().remove();
@@ -28,7 +28,7 @@ angular.module('yaru22.jsonHuman', [
     }
   };
   return RecursionHelper;
-}]).directive('jsonHuman', function () {
+}).directive('jsonHuman', function () {
   return {
     restrict: 'A',
     scope: {
@@ -49,7 +49,7 @@ angular.module('yaru22.jsonHuman', [
       });
     }
   };
-}).directive('jsonHumanHelper', ['RecursionHelper', function (RecursionHelper) {
+}).directive('jsonHumanHelper', function (RecursionHelper) {
   return {
     restrict: 'A',
     scope: {
@@ -60,4 +60,4 @@ angular.module('yaru22.jsonHuman', [
       return RecursionHelper.compile(tElem);
     }
   };
-}]);
+});


### PR DESCRIPTION
The jsonHumanHelper directive uses angular's ability to infer dependencies, which only works when the code is not minified.  This simply adds an annotation to the directive definition.
