### PR TITLE
Add entry point property to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,8 @@
     "karma-mocha": "~0.1",
     "matchdep": "~0.3.0"
   },
+  
+  "main": "dist/angular-json-human.js",
 
   "scripts": {
     "test": "grunt test"


### PR DESCRIPTION
By adding an entry point to `package.json` (main property) this package can then be imported into projects with ECMAScript modules and requireJS.

```js
import 'angular-json-human';
```

Without this property, however, the parser does not know which file to use and will throw an error about being unable to resolve the import statement.